### PR TITLE
$.nl was renamed to $.nl-out and $.nl-in

### DIFF
--- a/lib/IO/String.pm
+++ b/lib/IO/String.pm
@@ -43,7 +43,7 @@ class IO::String:ver<0.1.0>:auth<hoelzro> is IO::Handle {
     }
 
     method print-nl {
-        self.print($.nl);
+        self.print($.nl-out);
     }
 
     #| Returns, as a string, everything that's been written to

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -9,6 +9,8 @@ my $s = IO::String.new;
     my $*OUT = $s;
 
     say 'hello, world!';
+
+    $s.print-nl;
 }
 
-is ~$s, "hello, world!\n", "contents of IO::String should match what's been printed" or diag(~$s);
+is ~$s, "hello, world!\n\n", "contents of IO::String should match what's been printed" or diag(~$s);


### PR DESCRIPTION
This fixes a bug in print-nl and adds a test that will reveal the issue. I don't know why say() is not enough, but for some reason it isn't (I didn't look into it very hard).
