### PR TITLE
Implement .say

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/lib/.precomp/

--- a/lib/IO/String.pm
+++ b/lib/IO/String.pm
@@ -166,6 +166,11 @@ class IO::String:ver<0.1.0>:auth<hoelzro> is IO::Handle {
         self.print-nl;
     }
 
+    method say(IO::String:D: **@what is raw --> True) {
+        self.print(@what.map: *.gist);
+        self.print-nl;
+    }
+
     #| Returns, as a string, everything that's been written to
     #| this object.
     multi method Str(IO::String:D:) { $!buffer }

--- a/t/04-bind.t
+++ b/t/04-bind.t
@@ -2,7 +2,7 @@ use v6;
 use Test;
 use IO::String;
 
-plan 6;
+plan 8;
 
 my $buf = '';
 my $s = IO::String.new(buffer => $buf);
@@ -19,3 +19,9 @@ $s.open($buf, :a);
 $s.say("Jello");
 is $s.buffer, "Bellow\nJello\n", 'buffer is good after "regular" open';
 is $buf, "Bellow\n", 'original is unchanged after "regular" open';
+
+with class { method gist { 'gisted' } }.new -> \c {
+    is-deeply $s.say(c, (c, c).Seq, [c, c]), True, '.say returns True';
+    is-deeply $s.buffer, "Bellow\nJello\ngisted(gisted gisted)[gisted gisted]\n",
+        '.say gists';
+}


### PR DESCRIPTION
- Do not rely on IO::Handle.say's internal details
- Test .say actually gists
- Add lib/.precomp to .gitignore

This fixes current test failures due to changed IO::Handle.say implementation