### PR TITLE
Fix .lines and .get

### DIFF
--- a/lib/IO/String.pm
+++ b/lib/IO/String.pm
@@ -98,6 +98,13 @@ class IO::String:ver<0.1.0>:auth<hoelzro> is IO::Handle {
         $!pos = $a ?? $!buffer.chars !! 0;
     }
 
+    method lines(IO::String:D: $limit? is copy) {
+        $limit = Inf if not $limit.DEFINITE or $limit ~~ Whatever;
+        gather {
+            .take while ++$ <= $limit and ($_ = self.get).DEFINITE
+        }
+    }
+
     method get(IO::String:D:) {
         return Nil if $!pos >= $.buffer.chars;
 
@@ -105,7 +112,8 @@ class IO::String:ver<0.1.0>:auth<hoelzro> is IO::Handle {
         my $next-nl = [min] $.nl-in.map({
             $_ => $^nl with $.buffer.index($^nl, $start)
         }).grep(*.key.defined);
-        without $next-nl {
+
+        if $next-nl ~~ Num { # if it's Inf, then there's no minimum
             $!pos = $.buffer.chars;
             return $.buffer.substr($start);
         }

--- a/t/03-get.t
+++ b/t/03-get.t
@@ -2,7 +2,7 @@ use v6;
 use Test;
 use IO::String;
 
-plan 24;
+plan 25;
 
 # get, unix, chomp
 {
@@ -46,4 +46,9 @@ plan 24;
     is $s.get, "world!\r\n", "got second line";
     ok !$s.get, "got nothing for third line";
     ok $s.eof, "we have eof";
+}
+
+{
+    my $s = IO::String.new(buffer => "hello-world");
+    is-deeply $s.get, 'hello-world', 'have no new lines';
 }

--- a/t/05-lines.t
+++ b/t/05-lines.t
@@ -2,7 +2,7 @@ use v6;
 use Test;
 use IO::String;
 
-plan 16;
+plan 20;
 
 # lines, unix, chomp
 {
@@ -42,4 +42,16 @@ plan 16;
     is @lines[0], "hello,\r\n", "got first line";
     is @lines[1], "world!\r\n", "got second line";
     ok $s.eof, "we have eof";
+}
+
+{ # limit
+    my $s = IO::String.new(buffer => "hello,\r\nworld!\r\n");
+    is-deeply $s.lines(0), ().Seq, '.lines(0)';
+    is-deeply $s.lines(1), ("hello,",).Seq, '.lines(1)';
+
+    $s = IO::String.new(buffer => "hello,\r\nworld!\r\n");
+    is-deeply $s.lines(500), <hello, world!>.Seq, '.lines(500)';
+
+    $s = IO::String.new(buffer => "hello,\r\nworld!\r\n");
+    is-deeply $s.lines(*), <hello, world!>.Seq, '.lines(*)';
 }


### PR DESCRIPTION
- Do not assume IO::Handle.lines is implemented in terms of .get
    (fixes regression for latest Rakudo)
- `min` returns Inf on empty lists; fix bug in .get for when there
    are no new lines found