### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: perl6
 install:
-  - rakudobrew build-panda
+  - rakudobrew build-zef
 before_script:
-  - panda installdeps .
-  - panda-build
+  - zef --debug --depsonly install .
 
 script:
-  - panda-test
+  - zef --debug install .


### PR DESCRIPTION
panda is no longer available in rakudobrew

Unsure what `panda-build` does, but I think the replacement `zef` commands should do the trick. The `--debug` switch makes zef spew out more info during install/testing