### PR TITLE
Bump version

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
     "perl": "6.*",
     "name": "IO::String",
     "license" : "MIT",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Emulate file interface for strings",
     "provides": {
         "IO::String": "lib/IO/String.pm"


### PR DESCRIPTION
It appears `zef` goes by version numbers, so users don't get all
the latest bug fixes, because the version never got bumped.

Fixes #10